### PR TITLE
Add base16 and the set-color (sc) command

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "terminal/base16-shell"]
+  path = terminal/base16-shell
+  url = https://github.com/chriskempson/base16-shell.git
+  branch = master

--- a/files.csv
+++ b/files.csv
@@ -2,6 +2,7 @@ is_dir,source,target
 False,vim/vimrc,.vimrc
 False,terminal/alacritty.yml,.alacritty.yml
 False,vim/init.vim,.config/nvim/init.vim
+False,terminal/base16-shell,.config/base16-shell
 True,vim/spell,.config/nvim/spell
 True,vim,.vim
 False,git/gitconfig,.gitconfig

--- a/shell/zshenv
+++ b/shell/zshenv
@@ -140,3 +140,124 @@ function bounce() {
 }
 
 alias "t"="tmux"
+
+luma() {
+  emulate -L zsh
+
+  local COLOR_HEX=$1
+
+  if [ -z "$COLOR_HEX" ]; then
+    echo "Missing argument hex color (RRGGBB)"
+    return 1
+  fi
+
+  # Extract hex channels from background color (RRGGBB).
+  local COLOR_HEX_RED=$(echo "$COLOR_HEX" | cut -c 1-2)
+  local COLOR_HEX_GREEN=$(echo "$COLOR_HEX" | cut -c 3-4)
+  local COLOR_HEX_BLUE=$(echo "$COLOR_HEX" | cut -c 5-6)
+
+  # Convert hex colors to decimal.
+  local COLOR_DEC_RED=$((16#$COLOR_HEX_RED))
+  local COLOR_DEC_GREEN=$((16#$COLOR_HEX_GREEN))
+  local COLOR_DEC_BLUE=$((16#$COLOR_HEX_BLUE))
+
+  # Calculate perceived brightness of background per ITU-R BT.709
+  # https://en.wikipedia.org/wiki/Rec._709#Luma_coefficients
+  # http://stackoverflow.com/a/12043228/18986
+  local COLOR_LUMA_RED=$((0.2126 * $COLOR_DEC_RED))
+  local COLOR_LUMA_GREEN=$((0.7152 * $COLOR_DEC_GREEN))
+  local COLOR_LUMA_BLUE=$((0.0722 * $COLOR_DEC_BLUE))
+
+  local COLOR_LUMA=$(($COLOR_LUMA_RED + $COLOR_LUMA_GREEN + $COLOR_LUMA_BLUE))
+
+  echo "$COLOR_LUMA"
+}
+
+export BASE16_DIR=~/.config/base16-shell/scripts
+export BASE16_CONFIG="$HOME/.current-theme"
+color() {
+  emulate -L zsh
+
+  local SCHEME="$1"
+  local BASE16_CONFIG_PREVIOUS="$BASE16_CONFIG.previous"
+  local STATUS=0
+
+  __color() {
+    SCHEME=$1
+    local FILE="$BASE16_DIR/base16-$SCHEME.sh"
+    if [[ -e "$FILE" ]]; then
+      local BG=$(grep color_background= "$FILE" | cut -d \" -f2 | sed -e 's#/##g')
+      local LUMA=$(luma "$BG")
+      local LIGHT=$((LUMA > 127.5))
+      local BACKGROUND=dark
+      if [ "$LIGHT" -eq 1 ]; then
+        BACKGROUND=light
+      fi
+
+      if [ -e "$BASE16_CONFIG" ]; then
+        cp "$BASE16_CONFIG" "$BASE16_CONFIG_PREVIOUS"
+      fi
+
+      echo "$SCHEME" >! "$BASE16_CONFIG"
+      echo "$BACKGROUND" >> "$BASE16_CONFIG"
+      sh "$FILE"
+
+      if [ -n "$TMUX" ]; then
+        local CC=$(grep color18= "$FILE" | cut -d \" -f2 | sed -e 's#/##g')
+        if [ -n "$BG" -a -n "$CC" ]; then
+          command tmux set -a window-active-style "bg=#$BG"
+          command tmux set -a window-style "bg=#$CC"
+          command tmux set -g pane-active-border-bg "#$CC"
+          command tmux set -g pane-border-bg "#$CC"
+        fi
+      fi
+    else
+      echo "Scheme '$SCHEME' not found in $BASE16_DIR"
+      STATUS=1
+    fi
+  }
+
+  if [ $# -eq 0 ]; then
+    if [ -s "$BASE16_CONFIG" ]; then
+      cat "$BASE16_CONFIG"
+      local SCHEME=$(head -1 "$BASE16_CONFIG")
+      __color "$SCHEME"
+      return
+    else
+      SCHEME=help
+    fi
+  fi
+
+  case "$SCHEME" in
+  help)
+    echo 'color [tomorrow-night|ocean|grayscale-light|...]'
+    echo
+    echo 'Available schemes:'
+    color ls
+    return
+    ;;
+  ls)
+    find "$BASE16_DIR" -name 'base16-*.sh' | \
+      sed -E 's|.+/base16-||' | \
+      sed -E 's/\.sh//' | \
+      column
+      ;;
+  -)
+    if [[ -s "$BASE16_CONFIG_PREVIOUS" ]]; then
+      local PREVIOUS_SCHEME=$(head -1 "$BASE16_CONFIG_PREVIOUS")
+      __color "$PREVIOUS_SCHEME"
+    else
+      echo "warning: no previous config found at $BASE16_CONFIG_PREVIOUS"
+      STATUS=1
+    fi
+    ;;
+  *)
+    __color "$SCHEME"
+    ;;
+  esac
+
+  unfunction __color
+  return $STATUS
+}
+
+alias sc='color $(ls "$BASE16_DIR" | sed s/base16-//g | sed s/.sh//g | fzf --reverse)'

--- a/shell/zshrc
+++ b/shell/zshrc
@@ -35,6 +35,12 @@ antigen bundle zdharma/zsh-diff-so-fancy
 # # Tell Antigen that you're done.
 antigen apply
 
+# Base16 Shell
+BASE16_SHELL="$HOME/.config/base16-shell/"
+[ -n "$PS1" ] && \
+    [ -s "$BASE16_SHELL/profile_helper.sh" ] && \
+        eval "$("$BASE16_SHELL/profile_helper.sh")"
+
 # Vim mode
 bindkey -v
 autoload -U edit-command-line
@@ -138,3 +144,19 @@ source ~/.promptline.sh
 compdef g=git
 
 stty -ixon
+
+function () {
+  emulate -L zsh
+
+  if [[ -s "$BASE16_CONFIG" ]]; then
+    local SCHEME=$(head -1 "$BASE16_CONFIG")
+    local BACKGROUND=$(sed -n -e '2 p' "$BASE16_CONFIG")
+    if [ "$BACKGROUND" != 'dark' -a "$BACKGROUND" != 'light' ]; then
+      echo "warning: unknown background type in $BASE16_CONFIG"
+    fi
+    color "$SCHEME"
+  else
+    # Default.
+    color default-dark
+  fi
+}

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -21,6 +21,9 @@ set -g default-terminal "screen-256color"
 set -g base-index 1
 set -g renumber-windows on
 
+# Allow focus events inside tmux
+set -g focus-events on
+
 # Break and Join
 bind b break-pane -d
 bind J command-prompt -p "join pane from: "  "join-pane -h -s '%%'"

--- a/vim/after/plugin/color.vim
+++ b/vim/after/plugin/color.vim
@@ -1,0 +1,41 @@
+function s:CheckColorScheme()
+  if !has('termguicolors')
+    let g:base16colorspace=256
+  endif
+
+  let s:config_file = expand('~/.current-theme')
+
+  if filereadable(s:config_file)
+    let s:config = readfile(s:config_file, '', 2)
+
+    if s:config[1] =~# '^dark\|light$'
+      execute 'set background=' . s:config[1]
+    else
+      echoerr 'Bad background ' . s:config[1] . ' in ' . s:config_file
+    endif
+
+    let s:base_16_vim_config=expand(g:plugin_path . '/base16-vim/colors/base16-' . s:config[0] . '.vim')
+    if filereadable(s:base_16_vim_config)
+      execute 'color base16-' . s:config[0]
+    else
+      echoerr 'Bad scheme ' . s:config[0] . ' in ' . s:config_file
+    endif
+  else " default
+    set background=dark
+    color base16-default-dark
+  endif
+
+  execute 'highlight Comment ' . pinnacle#italicize('Comment')
+
+endfunction
+
+if v:progname !=# 'vi'
+  if has('autocmd')
+    augroup UpdateColorScheme
+      autocmd!
+      autocmd FocusGained * call s:CheckColorScheme()
+    augroup END
+  endif
+
+  call s:CheckColorScheme()
+endif

--- a/vim/plugin_config/base16.vim
+++ b/vim/plugin_config/base16.vim
@@ -1,0 +1,1 @@
+Plug 'chriskempson/base16-vim'

--- a/vim/plugin_config/fzf.vim
+++ b/vim/plugin_config/fzf.vim
@@ -1,7 +1,7 @@
 Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
 Plug 'junegunn/fzf.vim'
 
-nnoremap <Leader>ff :GFiles<CR>
+nnoremap <Leader>ff :GFiles?<CR>
 nnoremap <Leader>fg :Files .<CR>
 nnoremap <Leader>fb :Buffers<CR>
 nnoremap <Leader>fl :Lines<CR>

--- a/vim/plugin_config/pinnacle.vim
+++ b/vim/plugin_config/pinnacle.vim
@@ -1,0 +1,1 @@
+Plug 'wincent/pinnacle'

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -22,10 +22,12 @@ function! s:SourceConfigFilesIn(directory)
 endfunction
 
 if !has('nvim')
-  call plug#begin("~/.vim/bundle")
+  let g:plugin_path="~/.vim/bundle"
 else
-  call plug#begin("~/.local/share/nvim/plugged")
+  let g:plugin_path="~/.local/share/nvim/plugged"
 endif
+
+call plug#begin(g:plugin_path)
 call s:SourceConfigFilesIn("plugin_config")
 Plug 'Olical/vim-enmasse'
 call plug#end()


### PR DESCRIPTION
**Why** is the change needed?

Often when pairing with other developers I get the feedback that my
screen is very had to read. This PR attempts to resolve that issue by
allowing on-the-fly change of the entire color scheme.

Inspiration from
[Greg Hurrell](https://www.youtube.com/watch?v=QcOxU1sOOuw&feature=youtu.be):

- [Shell
  Functions](https://github.com/wincent/wincent/blob/f012c0a2b193c5735936babbd54f426e7e1f54c0/roles/dotfiles/files/.zsh/colors)
- [Vim
  Config](https://github.com/wincent/wincent/blob/f012c0a2b193c5735936babbd54f426e7e1f54c0/roles/dotfiles/files/.vim/after/plugin/color.vim)

**How** is the need addressed?

Add base16-shell as a submodule. Make sure that it is copied into the
`.config` folder. Copy a lot of code from Greg Hurrell.

Turn on focus events inside `tmux`. Add Greg's
[Pinnacle](https://github.com/wincent/pinnacle) plugin.

Change the fzf `:GFiles` → `:GFiles?` to display all files indexable by
git. This is what I wanted from the command originally.

What **side-effects** could the change have?

Adding a few global variables.

Closes #19