### PR TITLE
Fix path for git/global_hooks

### DIFF
--- a/files.csv
+++ b/files.csv
@@ -11,6 +11,7 @@ True,vim,.vim
 False,git/gitconfig,.gitconfig
 False,git/gitmessage,.gitmessage
 False,git/gitignore_global,.gitignore_global
+True,git/global_hooks,.config/git/global_hooks
 False,tmux/tmux.conf,.tmux.conf
 False,shell/bashrc,.bashrc
 False,shell/dircolors,.dircolors

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -6,7 +6,7 @@
   pager = "diff-so-fancy" | less -RFX
   whitespace = blank-at-eol,tab-in-indent
   excludesfile = "~/.gitignore_global"
-  hooksPath = "~/dotfiles/git/global_hooks"
+  hooksPath = "~/.config/git/global_hooks"
 [init]
   defaultBranch = main
 [diff]


### PR DESCRIPTION
**Why** is the change needed?

It was dependent on the location of my dotfiles repo.

Closes #188
