### PR TITLE
Make man and help full-screen

### DIFF
--- a/vim/autoload/jrasmusbm/help.vim
+++ b/vim/autoload/jrasmusbm/help.vim
@@ -5,4 +5,5 @@ function! jrasmusbm#help#help_mode()
   nnoremap <buffer> <bs> <c-T>
   nnoremap <buffer> q :q<CR>
   setlocal nonumber
+  only
 endfunction

--- a/vim/autoload/jrasmusbm/man.vim
+++ b/vim/autoload/jrasmusbm/man.vim
@@ -1,0 +1,4 @@
+function! jrasmusbm#man#man_mode()
+  setlocal nonumber
+  only
+endfunction

--- a/vim/ftplugin/help.vim
+++ b/vim/ftplugin/help.vim
@@ -1,0 +1,1 @@
+autocmd BufEnter <buffer> call jrasmusbm#help#help_mode()

--- a/vim/ftplugin/man.vim
+++ b/vim/ftplugin/man.vim
@@ -1,0 +1,1 @@
+autocmd BufEnter <buffer> call jrasmusbm#man#man_mode()

--- a/vim/other_config/help_files.vim
+++ b/vim/other_config/help_files.vim
@@ -1,3 +1,3 @@
-augroup HelpMode
-  autocmd filetype help call jrasmusbm#help#help_mode()
-augroup END
+" augroup HelpMode
+"   autocmd filetype help call jrasmusbm#help#help_mode()
+" augroup END


### PR DESCRIPTION
**Why** is the change needed?

I have a new setup where I only ever have one file open and rely on the
jumplist. This should work also with help and man.

**How** is the need addressed?

-   Add auto-commands that maximize windows when help or man is opened.

Closes #180
