### PR TITLE
Add long jumps to jump list

### DIFF
--- a/vim/other_config/remaps.vim
+++ b/vim/other_config/remaps.vim
@@ -14,4 +14,7 @@ nnoremap <silent> <leader>qc :cclose
 nnoremap <silent> <leader>lo :lopen
 nnoremap <silent> <leader>lc :lclose
 
+nnoremap <expr> j (v:count > 3 ? "m'" . v:count : "") . 'j'
+nnoremap <expr> k (v:count > 3 ? "m'" . v:count : "") . 'k'
+
 nmap == :call jrasmusbm#format#default()


### PR DESCRIPTION
**Why** is the change needed?

I use relative number jumps all the time, would be nice to have them in
the jump list.
