### PR TITLE
Update git-top so that it sorts numerically

### DIFF
--- a/bin/git-top
+++ b/bin/git-top
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 _show_top_contributors() {
-  git log --format=format:%an | sort | uniq -c | sort -r | head -n "${1:-20}"
+  count="${1:-20}"
+  git log --format=format:%an | sort | uniq -c | sort -gr | head -n "${1:-$count}"
 }
 
 _show_top_contributors "$@"


### PR DESCRIPTION
**Why** is the change needed?

The goal of the command is to show the top contributors, but those were
sorted as strings, which is not as useful.

Closes #246
