### PR TITLE
Add git-clr for a recursive clone

### DIFF
--- a/bin/git-clr
+++ b/bin/git-clr
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+_clone_recursively() {
+  g clone --recursive "$@"
+}
+
+_clone_recursively "$@"


### PR DESCRIPTION
**Why** is the change needed?

It's nice cause you don't have to go initiate the git submodules
separately.

Closes #247
