### PR TITLE
Add git-retag

### DIFF
--- a/bin/git-retag
+++ b/bin/git-retag
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+_retag() {
+   git tag -d "$1" 
+   git push origin ":refs/tags/$1"
+   git tag "$1"
+}
+
+_retag "$@"


### PR DESCRIPTION
**Why** is the change needed?

So that I can quickly update a tag in a branch (A number of repetitive
steps are normally needed.)

Closes #245
