### PR TITLE
Add git-cat for showing git commands

### DIFF
--- a/bin/git-cat
+++ b/bin/git-cat
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+_git_cat_alias() {
+  cat "$DOTFILES/bin/git-$1"
+}
+
+_git_cat_alias "$@"


### PR DESCRIPTION
**Why** is the change needed?

`git help` is not much use when working with files.

Closes #244
