### PR TITLE
Set lazyredraw

### DIFF
--- a/vim/other_config/basics.vim
+++ b/vim/other_config/basics.vim
@@ -17,3 +17,4 @@ set smartcase
 set incsearch
 set splitbelow
 set timeoutlen=300 ttimeoutlen=0
+set lazyredraw


### PR DESCRIPTION
**Why** is the change needed?

So that macros are performed instantly, speeding them up.

Closes #239
