### PR TITLE
Update the alacritty font

### DIFF
--- a/terminal/alacritty.yml
+++ b/terminal/alacritty.yml
@@ -15,22 +15,26 @@ scrolling:
 
 font:
   normal:
-    family: "UbuntuMono Nerd Font"
+    family: "JetBrainsMonoNL Nerd Font Mono"
     style: Regular
   bold:
-    family: "UbuntuMono Nerd Font"
+    family: "JetBrainsMonoNL Nerd Font Mono"
     style: Bold
   italic:
-    family: "UbuntuMono Nerd Font"
+    family: "JetBrainsMonoNL Nerd Font Mono"
     style: Italic
   bold_italic:
-    family: "UbuntuMono Nerd Font"
+    family: "JetBrainsMonoNL Nerd Font Mono"
     style: Bold Italic
 
-  size: 12.0
+  size: 10
   glyph_offset:
     x: 0
     y: -1
+
+  offset:
+    x: 1
+    y: 4
 
 # Change on the fly as needed
 background_opacity: 1


### PR DESCRIPTION
**Why** is the change needed?

It's been a while since I changed my font settings, thought it would be
fun to experiment. We'll see if I'll stick with it or have to keep
browsing other fonts.

**How** is the need addressed?

-   Clone the fonts from
    https://github.com/ryanoasis/nerd-fonts/tree/e505e99e679f4ab314dde0a93b19e73121b02777/patched-fonts/JetBrainsMono/NoLigatures
-   Put them in `~/.local/share/fonts/`
-   Update alacritty settings accordingly

Closes #257
