### PR TITLE
Add explicit filetypes for python and typescript

### DIFF
--- a/vim/compound-filetypes.md
+++ b/vim/compound-filetypes.md
@@ -1,0 +1,4 @@
+# Compound filetypes that I have used in the past
+
+- typescript.express
+- python.unittest

--- a/vim/lua/jrasmusbm/lsp/filetypes/python.lua
+++ b/vim/lua/jrasmusbm/lsp/filetypes/python.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.setup(options)
-  local poetry_venv_path = vim.fn.systemlist({ "poetry", "env" ,"info","-p" })[1]
+  local poetry_venv_path = vim.fn.systemlist({"poetry", "env", "info", "-p"})[1]
   local venv_path = vim.fn.getcwd() .. "/.venv"
   local python_path
 
@@ -13,13 +13,10 @@ function M.setup(options)
     python_path = "python3.8"
   end
 
-  require'lspconfig'.pyright.setup{
-    on_attach=options.on_attach,
-    settings={
-      python = {
-        pythonPath=python_path
-      }
-    }
+  require"lspconfig".pyright.setup {
+    on_attach = options.on_attach,
+    filetypes = {"python", "python.unittest"},
+    settings = {python = {pythonPath = python_path}},
   }
 end
 

--- a/vim/lua/jrasmusbm/lsp/filetypes/typescript.lua
+++ b/vim/lua/jrasmusbm/lsp/filetypes/typescript.lua
@@ -5,8 +5,8 @@ function M.setup(options)
         on_attach = function(client)
             client.resolved_capabilities.document_formatting = false
             options.on_attach(client)
-
-        end
+        end,
+        filetypes={"typescript", "typescript.express"}
     }
 end
 


### PR DESCRIPTION
**Why** is the change needed?

I use compound filetypes, which breaks the filetype recognition used by
the built-in lsp client.

Closes #268
