### PR TITLE
Use mpr in qpr

### DIFF
--- a/bin/git-mpr
+++ b/bin/git-mpr
@@ -20,11 +20,8 @@ _git_merge_pr() {
     return 1
   fi
 
-  g ch "$(g local-main-branch)"
-  g ff "$current_branch"
-  echo 'y' | g p
-  echo 'y' | g pd origin "$current_branch"
-  g bd "$current_branch"
+  gh pr merge -md
+  g mup
 }
 
 _git_merge_pr "$@"

--- a/bin/git-qpr
+++ b/bin/git-qpr
@@ -3,8 +3,7 @@
 _create_and_merge_pr() {
   g pup
   g opr -f
-  gh pr merge -md
-  g mup
+  g mpr
 }
 
 _create_and_merge_pr "$@"


### PR DESCRIPTION
**Why** is the change needed?

I added qpr after I added mpr. It's a better way of merging branches
since it relies on the official GitHub CLI.
