### PR TITLE
Add PIP_REQUIRE_VIRTUALENV=true to ~/.profile

### DIFF
--- a/shell/profile
+++ b/shell/profile
@@ -12,6 +12,8 @@ unset GTK_IM_MODULES
 unset QT_IM_MODULES
 
 export DOTFILES="$HOME/dotfiles"
+export PIP_REQUIRE_VIRTUALENV=true # use --isolated to bypass
+
 
 # if running bash
 if [ -n "$BASH_VERSION" ]; then


### PR DESCRIPTION
**Why** is the change needed?

So that I don't accidentally run pip outside venvs.

Closes #263
