### PR TITLE
feat(python): Make poetry create .venv in folder

### DIFF
--- a/python/poetry-config.toml
+++ b/python/poetry-config.toml
@@ -1,0 +1,2 @@
+virtualenvs.create = true
+virtualenvs.in-project = true

--- a/vim/lua/jrasmusbm/lsp/filetypes/python.lua
+++ b/vim/lua/jrasmusbm/lsp/filetypes/python.lua
@@ -1,13 +1,10 @@
 local M = {}
 
 function M.setup(options)
-  local poetry_venv_path = vim.fn.systemlist({"poetry", "env", "info", "-p"})[1]
   local venv_path = vim.fn.getcwd() .. "/.venv"
   local python_path
 
-  if vim.fn.isdirectory(poetry_venv_path) ~= 0 then
-    python_path = poetry_venv_path .. "/bin/python"
-  elseif vim.fn.isdirectory(venv_path) ~= 0 then
+  if vim.fn.isdirectory(venv_path) ~= 0 then
     python_path = venv_path .. "/bin/python"
   else
     python_path = "python"


### PR DESCRIPTION
**Why** is the change needed?

That way it works a lot better with existing tooling. It also mean I can
stop using extra poetry-specific configurations.

Closes #341
