### PR TITLE
367 fix reset back to original test executables

### DIFF
--- a/vim/ftplugin/pytest.lua
+++ b/vim/ftplugin/pytest.lua
@@ -4,6 +4,8 @@ local fmt = require("luasnip.extras.fmt").fmt
 local sn = ls.snippet_node
 local i = ls.insert_node
 
+vim.g["test#python#pytest#executable"] = "python -m pytest"
+
 require("jrasmusbm.dap.test").setup_test_debugging({
   ["test#python#pytest#executable"] = "python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m pytest",
 }, function() vim.cmd("Debugpy attach 0.0.0.0 5678") end)

--- a/vim/ftplugin/unittest.lua
+++ b/vim/ftplugin/unittest.lua
@@ -4,6 +4,8 @@ local fmt = require("luasnip.extras.fmt").fmt
 local sn = ls.snippet_node
 local i = ls.insert_node
 
+vim.g["test#python#pyunit#executable"] = "python -m unittest"
+
 require("jrasmusbm.dap.test").setup_test_debugging({
   ["test#python#pyunit#executable"] = "python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m unittest",
 }, function() vim.cmd("Debugpy attach 0.0.0.0 5678") end)

--- a/vim/lua/jrasmusbm/dap/test.lua
+++ b/vim/lua/jrasmusbm/dap/test.lua
@@ -1,29 +1,37 @@
 local M = {}
 
 local debug_test = function(cmd, debug_handlers, callback)
-  local original_handlers = {}
+  return function()
+    local original_handlers = {}
 
-  for k, v in pairs(debug_handlers) do
-    original_handlers[k] = vim.g[k]
-    vim.g[k] = v
+    for k, v in pairs(debug_handlers) do
+      original_handlers[k] = vim.g[k]
+      vim.g[k] = v
+    end
+
+    vim.cmd(cmd)
+
+    for k, v in pairs(original_handlers) do vim.g[k] = v end
+
+    local function retry_wrapper()
+      local ok = pcall(callback)
+
+      if ok ~= true then vim.defer_fn(retry_wrapper, 2000) end
+    end
+
+    vim.defer_fn(retry_wrapper, 2000)
   end
-
-  vim.cmd(cmd)
-
-  for k, v in pairs(original_handlers) do vim.g[k] = v end
-
-  vim.defer_fn(vim.schedule_wrap(callback), 500)
 end
 
 M.setup_test_debugging = function(...)
   vim.keymap.set({"n"}, "din", debug_test("TestNearest", ...),
-                 {noremap = true, buffer = 0})
+    {noremap = true, buffer = 0})
   vim.keymap.set({"n"}, "dip", debug_test("TestLast", ...),
-                 {noremap = true, buffer = 0})
+    {noremap = true, buffer = 0})
   vim.keymap.set({"n"}, "dif", debug_test("TestFile", ...),
-                 {noremap = true, buffer = 0})
+    {noremap = true, buffer = 0})
   vim.keymap.set({"n"}, "dis", debug_test("TestSuite", ...),
-                 {noremap = true, buffer = 0})
+    {noremap = true, buffer = 0})
 end
 
 return M


### PR DESCRIPTION
- fix: explicitly set the default executable
- fix: Return a callback in dap test helper
