### PR TITLE
feat: remove delay on debug

### DIFF
--- a/vim/ftplugin/pytest.lua
+++ b/vim/ftplugin/pytest.lua
@@ -8,7 +8,7 @@ vim.g["test#python#pytest#executable"] = "python -m pytest"
 
 require("jrasmusbm.dap.test").setup_test_debugging({
   ["test#python#pytest#executable"] = "python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m pytest",
-}, function() vim.cmd("Debugpy attach 0.0.0.0 5678") end)
+}, vim.schedule_wrap(function() vim.cmd("Debugpy attach 0.0.0.0 5678") end))
 
 local test_class =
   function() return fmt("class Test{}:\n    {}", {i(1), i(0)}) end

--- a/vim/ftplugin/unittest.lua
+++ b/vim/ftplugin/unittest.lua
@@ -8,7 +8,7 @@ vim.g["test#python#pyunit#executable"] = "python -m unittest"
 
 require("jrasmusbm.dap.test").setup_test_debugging({
   ["test#python#pyunit#executable"] = "python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m unittest",
-}, function() vim.cmd("Debugpy attach 0.0.0.0 5678") end)
+}, vim.schedule_wrap(function() vim.cmd("Debugpy attach 0.0.0.0 5678") end))
 
 local test_class = function()
   return fmt("class Test{}(unittest.TestCase):\n    {}", {i(1), i(0)})

--- a/vim/lua/jrasmusbm/dap/test.lua
+++ b/vim/lua/jrasmusbm/dap/test.lua
@@ -13,25 +13,18 @@ local debug_test = function(cmd, debug_handlers, callback)
 
     for k, v in pairs(original_handlers) do vim.g[k] = v end
 
-    local function retry_wrapper()
-      local ok = pcall(callback)
-
-      if ok ~= true then vim.defer_fn(retry_wrapper, 2000) end
-    end
-
-    vim.defer_fn(retry_wrapper, 2000)
+    callback()
   end
 end
 
 M.setup_test_debugging = function(...)
   vim.keymap.set({"n"}, "din", debug_test("TestNearest", ...),
-    {noremap = true, buffer = 0})
-  vim.keymap.set({"n"}, "dip", debug_test("TestLast", ...),
-    {noremap = true, buffer = 0})
+                 {noremap = true, buffer = 0})
+  vim.keymap.set({"n"}, "dip", debug_test("TestLast", ...), {noremap = true})
   vim.keymap.set({"n"}, "dif", debug_test("TestFile", ...),
-    {noremap = true, buffer = 0})
+                 {noremap = true, buffer = 0})
   vim.keymap.set({"n"}, "dis", debug_test("TestSuite", ...),
-    {noremap = true, buffer = 0})
+                 {noremap = true, buffer = 0})
 end
 
 return M


### PR DESCRIPTION
**Why** is the change needed?

I don't need to poll, I just trigger two runs consequtively, such that
the next is already ready when the first one finishes. That way I can
solve this in workflow instead of in code.

Closes #369
