### PR TITLE
fix: recover debugging after a crash

### DIFF
--- a/vim/lua/jrasmusbm/dap/test.lua
+++ b/vim/lua/jrasmusbm/dap/test.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 local debug_test = function(cmd, debug_handlers, callback)
-  return function()
+  return vim.schedule_wrap(function()
     local original_handlers = {}
 
     for k, v in pairs(debug_handlers) do
@@ -16,7 +16,7 @@ local debug_test = function(cmd, debug_handlers, callback)
     end
 
     callback()
-  end
+  end)
 end
 
 M.setup_test_debugging = function(...)


### PR DESCRIPTION
**Why** is the change needed?

I had an issue (fixed upstream) with nvim-dap where after an error
connecting (due to a non-terminated session), I had to restart neovim to
be able to debug again. Fixed it by bumping external library.

Closes #376
