### PR TITLE
fix: Migrate to docker compose 2

### DIFF
--- a/bin/dcd
+++ b/bin/dcd
@@ -4,5 +4,5 @@ set -e
 
 (
   set -x
-  docker-compose down --remove-orphans
+  docker compose down --remove-orphans
 )

--- a/bin/dcdc
+++ b/bin/dcdc
@@ -2,4 +2,4 @@
 
 set -e
 
-docker-compose -f docker-compose-check.y*ml down --remove-orphans
+docker compose -f docker compose-check.y*ml down --remove-orphans

--- a/bin/dcdd
+++ b/bin/dcdd
@@ -2,4 +2,4 @@
 
 set -e
 
-docker-compose -f docker-compose*dev.y*ml down --remove-orphans 
+docker compose -f docker compose*dev.y*ml down --remove-orphans 

--- a/bin/dcdt
+++ b/bin/dcdt
@@ -2,5 +2,5 @@
 
 set -e
 
-docker-compose -f docker-compose*test.y*ml down --remove-orphans 
-docker-compose -f docker-compose*test.y*ml up --build "$@"
+docker compose -f docker compose*test.y*ml down --remove-orphans 
+docker compose -f docker compose*test.y*ml up --build "$@"

--- a/bin/dcu
+++ b/bin/dcu
@@ -6,5 +6,5 @@ dcd
 
 (
   set -x
-  docker-compose up --remove-orphans --build "$@"
+  docker compose up --remove-orphans --build "$@"
 )

--- a/bin/dcuc
+++ b/bin/dcuc
@@ -3,4 +3,4 @@
 set -e
 
 dcdc
-docker-compose -f docker-compose-check.y*ml up --build "$@"
+docker compose -f docker compose-check.y*ml up --build "$@"

--- a/bin/dcud
+++ b/bin/dcud
@@ -3,4 +3,4 @@
 set -e
 
 dcdd
-docker-compose -f docker-compose*dev.y*ml up --build "$@"
+docker compose -f docker compose*dev.y*ml up --build "$@"

--- a/bin/dcut
+++ b/bin/dcut
@@ -3,4 +3,4 @@
 set -e
 
 dcdt
-docker-compose -f docker-compose*test.y*ml up --build "$@"
+docker compose -f docker compose*test.y*ml up --build "$@"

--- a/install_dependencies/docker
+++ b/install_dependencies/docker
@@ -2,7 +2,6 @@
 
 set -e
 
-
 install_docker() {
   sudo apt-get remove docker docker-engine docker.io containerd runc
   sudo apt-get install -y \
@@ -13,14 +12,23 @@ install_docker() {
     software-properties-common
   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
    $(lsb_release -cs) \
    stable"
   sudo apt-get update
   sudo apt-get install -y docker-ce docker-ce-cli containerd.io
-  sudo usermod -aG docker ${USER}
-  sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-  sudo chmod +x /usr/local/bin/docker-compose
+  sudo usermod -aG docker "${USER}"
+  sudo chmod +x /usr/local/bin/docker compose
+
+}
+
+install_docker_compose() {
+  DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+  mkdir -p "$DOCKER_CONFIG/cli-plugins"
+  curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker compose-linux-x86_64 -o "$DOCKER_CONFIG/cli-plugins/docker compose"
+
+  chmod +x "$DOCKER_CONFIG/cli-plugins/docker compose"
 }
 
 install_docker
+install_docker_compose

--- a/vim/ftplugin/yaml.vim
+++ b/vim/ftplugin/yaml.vim
@@ -3,8 +3,8 @@ execute "source $DOTFILES/vim/snippets/yaml.vim"
 function! RunFile() abort
   w
   let path = shellescape(@%, 1)
-  exec 'VtrSendCommandToRunner docker-compose -f ' . path . ' down --remove-orphans'
-  exec 'VtrSendCommandToRunner docker-compose -f ' . path . ' up --remove-orphans --build'
+  exec 'VtrSendCommandToRunner docker compose -f ' . path . ' down --remove-orphans'
+  exec 'VtrSendCommandToRunner docker compose -f ' . path . ' up --remove-orphans --build'
 endfunction
 
 nnoremap <buffer> <leader>c :call RunFile()


### PR DESCRIPTION
**Why** is the change needed?

It is now bundled as a docker plugin, instead of as a standalone CLI.
There were deprecation warnings at work, so it felt like it was time to
upgrade.

Closes #385
