### PR TITLE
fix(auto-pairs): disable AutoPairsMoveCharacter

### DIFF
--- a/vim/plugin/matching.lua
+++ b/vim/plugin/matching.lua
@@ -1,6 +1,8 @@
 vim.cmd [[
-" packadd auto-pairs
+packadd auto-pairs
 packadd matchit
 packadd vim-endwise
 packadd vim-surround
 ]]
+
+vim.g.AutoPairsMoveCharacter = ""


### PR DESCRIPTION
**Why** is the change needed?

For some very strange reason, the binding of <M-[> results in very
annoying behavior where random number get input, breaking the editing
experience.

Closes: #402
