### PR TITLE
feat(git): enable parallelIndex

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -7,6 +7,7 @@
   whitespace = blank-at-eol,tab-in-indent
   excludesfile = "~/.ignore"
   hooksPath = "~/.config/git/global_hooks"
+  preloadindex = true
 [init]
   defaultBranch = main
 [diff]


### PR DESCRIPTION
**Why** is the change needed?

Allows git to perform indexing in parallel, improving perfomance.

Closes: #434
