### PR TITLE
feat(layout): support toggling layouts and themes

### DIFF
--- a/bin/layout
+++ b/bin/layout
@@ -24,8 +24,8 @@ _update_xrandr() {
   elif test "$1" = 'doktor'; then
     xrandr --output 'DP-1-1' --auto --right-of eDP-1
   elif test "$1" = 'laptop'; then
-    xrandr --output 'HDMI-1' --off
-    xrandr --output 'DP-1-1' --off
+    xrandr --output 'HDMI-1' --off 2>/dev/null || true
+    xrandr --output 'DP-1-1' --off 2>/dev/null || true
   fi
 }
 
@@ -55,6 +55,14 @@ _matches_option() {
   test -n "$matches"
 }
 
+_get_supported_layouts() {
+  for _path in "$DOTFILES/layouts/"*; do
+    if "$_path" 'supported'; then
+      echo "${_path##*/}"
+    fi
+  done
+}
+
 _set_layout() {
   _config_file="$HOME/.config/jrasmusbm/layout"
 
@@ -63,18 +71,25 @@ _set_layout() {
     return 0
   fi
 
-  _supported_layouts='(laptop|home|stream|doktor)'
+  _supported_layouts="($(_get_supported_layouts | tr -s '\n' '|' | sed -E 's/.$//'))"
+
+  if test "$1" = 'supported'; then
+    echo "$_supported_layouts"
+    return 0
+  fi
+
   _layout="$1"
 
   if ! _matches_option "$_supported_layouts" "$_layout"; then
-    printf 'Usage: set-layout %s\n' "$_supported_layouts"
-    exit 1
+    printf 'Usage: set-layout %s\n' "$_supported_layouts" exit 1
   fi
 
   _persist_layout "$_layout"
   _update_screenkey "$_layout"
   _update_xrandr "$_layout"
   _update_fsize "$_layout"
+
+  refresh-i3status
 }
 
 _set_layout "$@"

--- a/bin/my-i3status
+++ b/bin/my-i3status
@@ -4,5 +4,5 @@ set -e
 
 i3status | while :; do
   read -r line
-  echo "$(pomo_status) | 🔦 $(brightness current) | $line" || exit 1
+  echo "$(theme emoji) $(layout show) | $(pomo_status) | 🔦 $(brightness current) | $line" || exit 1
 done

--- a/bin/refresh-i3status
+++ b/bin/refresh-i3status
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+killall -SIGUSR1 i3status

--- a/bin/theme
+++ b/bin/theme
@@ -18,7 +18,7 @@ _set_vscode_theme() {
 }
 
 _set_system_theme() {
-  type dconf > /dev/null && dconf write '/org/gnome/desktop/interface/gtk-theme' "'Yaru-$1'"
+  type dconf >/dev/null && dconf write '/org/gnome/desktop/interface/gtk-theme' "'Yaru-$1'"
 }
 
 _persist_theme() {
@@ -31,15 +31,42 @@ _set_theme() {
     return 0
   fi
 
-  if test "$1" != 'light' -a "$1" != 'dark'; then
+  if test "$1" = 'emoji'; then
+    _current_theme="$(cat "$HOME/.config/jrasmusbm/theme")"
+
+    if test "$_current_theme" = 'dark'; then
+      printf '🌚'
+    elif test "$_current_theme" = 'light'; then
+      printf '🔆'
+    else
+      printf '%s' "$_current_theme"
+    fi
+
+    return 0
+  fi
+
+  if test "$1" != 'light' -a "$1" != 'dark' -a "$1" != 'toggle'; then
     echo "Usage: _set_theme (light|dark)"
     exit 1
   fi
 
-  _set_alacritty_theme "$1"
-  _set_system_theme "$1"
-  _set_vscode_theme "$1"
-  _persist_theme "$1"
+  if test "$1" = 'toggle'; then
+    _old_theme="$(cat "$HOME/.config/jrasmusbm/theme")"
+    if test "$_old_theme" = 'dark'; then
+      _new_theme='light'
+    elif test "$_old_theme" = 'light'; then
+      _new_theme='dark'
+    fi
+  else
+    _new_theme="$1"
+  fi
+
+  _set_alacritty_theme "$_new_theme"
+  _set_system_theme "$_new_theme"
+  _set_vscode_theme "$_new_theme"
+  _persist_theme "$_new_theme"
+
+  refresh-i3status
 }
 
 _set_theme "$@"

--- a/bin/toggle-layout
+++ b/bin/toggle-layout
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+_toggle_layout() {
+  (
+
+    _current_layout="$(layout show)"
+    echo "Current layout is: $_current_layout" >/dev/stderr
+
+    _supported_layouts="$(layout supported | tr -d "()" | tr -s '|' '\n')"
+    echo "Current layouts are: $_supported_layouts" >/dev/stderr
+
+    _n_layouts="$(echo "$_supported_layouts" | wc -l)"
+    echo "$_n_layouts"
+
+    _current_layout_position="$(echo "$_supported_layouts" | awk "/$_current_layout/ { print NR }")"
+    if test -z "$_current_layout_position"; then
+      _current_layout_position=0
+    fi
+    echo "Current layout position is: $_current_layout_position" >/dev/stderr
+
+    _next_layout_position="$(((_current_layout_position + 1) % (_n_layouts + 1)))"
+    if test "$_next_layout_position" = '0'; then
+      _next_layout_position=1
+    fi
+
+    echo "Next layout position is: $_next_layout_position" >/dev/stderr
+
+    _next_layout="$(echo "$_supported_layouts" | awk "NR == $_next_layout_position { print $1 }")"
+    
+    echo "$_next_layout" > /dev/stderr
+    layout "$_next_layout"
+  )
+}
+
+_toggle_layout "$@"

--- a/layouts/doktor
+++ b/layouts/doktor
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+_layout() {
+  if test "$1" = 'supported'; then
+    xrandr | grep -q 'DP-1-1 connected'
+    exit $?
+  fi
+}
+
+_layout "$@"

--- a/layouts/home
+++ b/layouts/home
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+_layout() {
+  if test "$1" = 'supported'; then
+    xrandr | grep -q 'HDMI-1 connected'
+    exit $?
+  fi
+}
+
+_layout "$@"

--- a/layouts/laptop
+++ b/layouts/laptop
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+_layout() {
+  if test "$1" = 'supported'; then
+    return 0
+  fi
+}
+
+_layout "$@"

--- a/layouts/stream
+++ b/layouts/stream
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+_layout() {
+  if test "$1" = 'supported'; then
+    xrandr | grep -q 'HDMI-1 connected'
+    exit $?
+  fi
+}
+
+_layout "$@"

--- a/window_manager/i3/config
+++ b/window_manager/i3/config
@@ -43,6 +43,9 @@ bindsym $mod+b exec --no-startup-id brave-browser
 bindsym $mod+d exec --no-startup-id dmenu_run
 bindsym $mod+p exec --no-startup-id start_scratchpad
 bindsym $mod+i exec --no-startup-id i3-input -F 'exec yso %s'
+bindsym $mod+F6 exec --no-startup-id theme toggle
+bindsym $mod+F7 exec --no-startup-id zsh -c 'toggle-layout 2> /dev/null'
+bindsym XF86Display exec --no-startup-id zsh -c 'toggle-layout 2> /dev/null'
 bindsym Print exec --no-startup-id screenshot
 bindsym Shift+Print exec --no-startup-id screenshot --area
 bindsym Control+Print exec --no-startup-id screenshot --window


### PR DESCRIPTION
**Why** is the change needed?

Very often I am stuck on a i3 pane that is located on a disconnected
monitor. Having a quick key binding to fix this makes that a lot less
annoying.

Closes #452
