### PR TITLE
feat(tmux): support opening file to line number

### DIFF
--- a/bin/open
+++ b/bin/open
@@ -20,7 +20,12 @@ def main():
         run(["git-open", path.split(":")[1][:-4]])
         return
 
-    run(["nr", "--remote", path])
+    path_components = path.split(":")
+    if len(path_components) > 1:
+        run(["nr", f"+{path_components[1]}", "--remote", path_components[0]])
+        return
+
+    run(["nr", "--remote", path_components[0]])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Why** is the change needed?

When running tsc for type checking, a line number is included. Being
able to open the file to that line number is a very nice UX.

Closes: #453
