### PR TITLE
fix(tmux): attach to sessions in _all_sessions

### DIFF
--- a/bin/ta
+++ b/bin/ta
@@ -52,6 +52,7 @@ _all_sessions() {
   selected_session_path="$(echo "$selected_session_path" | head -1)"
 
   _start_project "$selected_session_path"
+  tmux-attach-to-session "$(tmux-session-name-from-path "$selected_session_path")"
 }
 
 _multiple_sessions() {


### PR DESCRIPTION
**Why** is the change needed?

It was caused by adding INITIATED_EXTERNALLY to the common function
starting the projects.

Closes: #465
