### PR TITLE
fix(shell): replace prompt symbol

### DIFF
--- a/bin/tmux-next-prompt
+++ b/bin/tmux-next-prompt
@@ -2,7 +2,7 @@
 
 set -e
 
-unique_prompt_symbol='›'
+unique_prompt_symbol='➶'
 
 tmux send -X end-of-line
 tmux send -X search-forward-text "$unique_prompt_symbol"

--- a/bin/tmux-prev-prompt
+++ b/bin/tmux-prev-prompt
@@ -2,7 +2,7 @@
 
 set -e
 
-unique_prompt_symbol='›'
+unique_prompt_symbol='➶'
 
 tmux send -X start-of-line
 tmux send -X search-backward-text "$unique_prompt_symbol"

--- a/shell/zshrc
+++ b/shell/zshrc
@@ -155,12 +155,12 @@ function () {
   if [[ -n "$TMUX" ]]; then
     # Note use a non-breaking space at the end of the prompt because we can use it as
     # a find pattern to jump back in tmux.
-    export PS1="%F{green}${SSH_TTY:+%n@%m}%f%B${SSH_TTY:+:}%b%F{blue}%1~%F{yellow}%B%(1j.*.)%(?..!)%b%f%F{red}%B${SUFFIX}%b%f › "
+    export PS1="%F{green}${SSH_TTY:+%n@%m}%f%B${SSH_TTY:+:}%b%F{blue}%1~%F{yellow}%B%(1j.*.)%(?..!)%b%f%F{red}%B${SUFFIX}%b%f %F{blue}➶%b%f "
     export ZLE_RPROMPT_INDENT=0
   else
     # Don't bother with ZLE_RPROMPT_INDENT here, because it ends up eating the
     # space after PS1.
-    export PS1="%F{green}${SSH_TTY:+%n@%m}%f%B${SSH_TTY:+:}%b%F{blue}%1~%F{yellow}%B%(1j.*.)%(?..!)%b%f%F{red}%B${SUFFIX}%b%f › "
+    export PS1="%F{green}${SSH_TTY:+%n@%m}%f%B${SSH_TTY:+:}%b%F{blue}%1~%F{yellow}%B%(1j.*.)%(?..!)%b%f%F{red}%B${SUFFIX}%b%f %F{blue}➶%b "
   fi
 }
 


### PR DESCRIPTION
**Why** is the change needed?

Jest was using the same symbol, interfering with my scripts for grabbing
output.

Closes: #504
