### PR TITLE
chore: remove gh

### DIFF
--- a/bin/gt
+++ b/bin/gt
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set -e
-
-_graphite_cli() {
-  node "$HOME/projects/graphite-cli/dist/src/index.js" "$@"
-}
-
-_graphite_cli "$@"


### PR DESCRIPTION
**Why** is the change needed?

I will now use the homebrew version

Closes: #566
