### PR TITLE
fix: delete the correct session

### DIFF
--- a/bin/tks
+++ b/bin/tks
@@ -14,10 +14,8 @@ tmux_kill_session() {
     exit 1
   fi
 
-  for window in $(tmux list-windows -F '#{window_name}' -t "$session"); do
-    for pane_pid in $(tmux list-panes -F '#{pane_pid}' -t "$window"); do
-      nohup kill-descendants "$pane_pid" >/dev/null 2>&1 &
-    done
+  for pane_pid in $(tmux list-panes -s -F '#{pane_pid}' -t "$session"); do
+    nohup kill-descendants "$pane_pid" >/dev/null 2>&1 &
   done
 
   (


### PR DESCRIPTION
Closes: #570

The list-panes command was just being fed with the name of the panes,
which could be from any tmux-session, not the target.

Example:

```sh
$ tmux list-windows -F '#{window_name}' -t "witchcraft"
  \ | x -n 1 echo tmux list-panes -F '#{pane_pid}' -t
tmux list-panes -F #{pane_pid} -t run
tmux list-panes -F #{pane_pid} -t vim
tmux list-panes -F #{pane_pid} -t cli
```
